### PR TITLE
Loosened dependency on symfony console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .idea
 vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     ],
     "require": {
         "pda/pheanstalk": "dev-master",
-        "symfony/console": "2.1.*"
+        "symfony/console": "~2.1"
     }
 }


### PR DESCRIPTION
The "~2.1" is equivalent to ">=2.1.0,<3.0.0" allows for other packages to dictate exact minor revision of console to run. 

As of right now there are no BC breaks in Symfony Console 2.2.x or 2.3.x
