### PR TITLE
Fixed Pheanstalk_Job classname

### DIFF
--- a/src/Bstools/Command/Delete.php
+++ b/src/Bstools/Command/Delete.php
@@ -21,7 +21,7 @@ class Delete extends Base
         $pheanstalk = $this->createConnection($input);
 
         $jobId = $input->getArgument('jobid');
-        $job = new \Pheanstalk_Pheanstalk_Job($jobId, null);
+        $job = new \Pheanstalk_Job($jobId, null);
         $pheanstalk->delete($job);
         $output->writeln("<info>Deleted $jobId...</info>");
     }


### PR DESCRIPTION
When you try to delete a job you get an error, that class Pheanstalk_Pheanstalk_Job can not be found. This fixes it.
