### PR TITLE
Add an alternative renderer for `bs stats` output

### DIFF
--- a/src/Bstools/Renderer/Raw.php
+++ b/src/Bstools/Renderer/Raw.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bstools\Renderer;
+
+class Raw implements RendererInterface
+{
+    /**
+     * @return string
+     */
+    public function render(array $data)
+    {
+        $output = array();
+
+        foreach ($data as $tubename => $tubedata) {
+            foreach ($tubedata as $title => $value) {
+                $output[] = sprintf("%s\t%s\t%d", $tubename, $title, $value);
+            }
+        }
+
+        return implode("\n", $output);
+    }
+}

--- a/src/Bstools/Renderer/RendererInterface.php
+++ b/src/Bstools/Renderer/RendererInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bstools\Renderer;
+
+interface RendererInterface
+{
+    /**
+     * @param array $data
+     *
+     * @return string
+     */
+    public function render(array $data);
+}

--- a/src/Bstools/Renderer/Table.php
+++ b/src/Bstools/Renderer/Table.php
@@ -1,22 +1,16 @@
 <?php
 
-namespace Bstools;
+namespace Bstools\Renderer;
 
-class Table
+class Table implements RendererInterface
 {
-    protected $data;
-    public function __construct($data)
-    {
-        $this->data = $data;
-    }
-
-    public function render()
+    public function render(array $statsData)
     {
         $columns = array();
         $columnWidths = array();
         $output = "";
 
-        foreach ($this->data as $data) {
+        foreach ($statsData as $data) {
             foreach ($data as $key => $val) {
                 $columns[] = $key;
             }
@@ -24,13 +18,13 @@ class Table
         $columns = array_unique($columns);
         sort($columns);
 
-        $rows = array_keys($this->data);
+        $rows = array_keys($statsData);
 
         $columnWidths["rows"] = $this->getMaxLength($rows);
         foreach ($columns as $column) {
             $tempValues = array();
             $tempValues[] = $column;
-            foreach ($this->data as $tube => $data) {
+            foreach ($statsData as $tube => $data) {
                 $tempValues[] = $data[$column];
             }
             $columnWidths[$column] = $this->getMaxLength($tempValues);
@@ -50,7 +44,7 @@ class Table
         $output .= $dividerLine;
 
         //output rows
-        foreach ($this->data as $tube => $data) {
+        foreach ($statsData as $tube => $data) {
             $output .= "| ";
             $output .= str_pad($tube, $columnWidths["rows"], ' ', STR_PAD_LEFT);
             $output .= " | ";


### PR DESCRIPTION
For scripting purposes a raw output is preferable over the rendered
table. This pull request introduces different renderer classes, the
existing `Table` renderer and the new `Raw` renderer. It displays
the tube data in a machine readable form (tab delimited rows).

The renderer can be selected by adding the `-e` option to the
`bs stats` command. If the option is missing the tool behaves as before.

All other options are unchanged so there're no compatibility issues.
